### PR TITLE
To fix the issue with MAX_BYTES_PER_CS parameter

### DIFF
--- a/Verilog/source/SPI_Master_With_Single_CS.v
+++ b/Verilog/source/SPI_Master_With_Single_CS.v
@@ -114,7 +114,7 @@ module SPI_Master_With_Single_CS
         begin
           if (r_CS_n & i_TX_DV) // Start of transmission
           begin
-            r_TX_Count <= i_TX_Count - 1; // Register TX Count
+            r_TX_Count <= MAX_BYTES_PER_CS - 1; // Register TX Count
             r_CS_n     <= 1'b0;       // Drive CS low
             r_SM_CS    <= TRANSFER;   // Transfer bytes
           end


### PR DESCRIPTION
If to load the value of "MAX_BYTES_PER_CS" it fixes the issue with incorrect behavior of r_TX_Count when it is loading with overflow. 

Related to this issue: [MAX_BYTES_PER_CS parameter's behavior doesn't follow it's description in SPI_Master_With_Single_CS #2](https://github.com/nandland/spi-master/issues/2)